### PR TITLE
Add arc npm commands and install deps when compiling templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "deploy": "NODE_ENV=production npm run build-deploy",
     "start": "npm run compile-templates && AWS_PROFILE=default AWS_REGION=us-east-1 NODE_ENV=testing arc-sandbox",
     "build": "rm -rf ./build ./src/html/get-index/static ./src/html/get-index/cache && npm run compile-templates && PREBUILD=1 lasso marko-hydrate:./src/html/get-index/page.marko --config ./src/html/get-index/lasso-config --name get-index",
-    "compile-templates": "NODE_ENV=production marko compile --server --ignore ./src/**/node_modules/** --files ./src/**/*.marko"
+    "compile-templates": "npm run arc-install && NODE_ENV=production marko compile --server --ignore ./src/**/node_modules/** --files ./src/**/*.marko",
+    "arc-install": "arc-modules-install",
+    "arc-link": "arc-modules-link",
+    "arc-uninstall": "arc-modules-uninstall",
+    "arc-update": "arc-modules-update"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This will allow you to actually just do `npm install` and then `npm start` and be up and running locally